### PR TITLE
fix preventDefault invalid in ios11.3

### DIFF
--- a/src/js/app/LoadViewController.js
+++ b/src/js/app/LoadViewController.js
@@ -16,7 +16,7 @@ var initProject = function () {
     // 防止微信下拉
     $(document.documentElement).on('touchmove', function (e) {
         e.preventDefault();
-    });
+    }, { passive: false });
 };
 
 // 加载页对象


### PR DESCRIPTION
e.preventDefault of touchmove event is invalid in ios11.3, add "{passive:false}" argumengt can fix this problem.

reference: https://segmentfault.com/a/1190000014134234